### PR TITLE
Add per-effect intensity sliders and persistence

### DIFF
--- a/src/main/kotlin/com/zeus/thunderbolt/SettingsUI.kt
+++ b/src/main/kotlin/com/zeus/thunderbolt/SettingsUI.kt
@@ -4,8 +4,10 @@ import com.intellij.openapi.options.Configurable
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
+import java.awt.BorderLayout
 import javax.swing.JComponent
 import javax.swing.JComboBox
+import javax.swing.JSlider
 import javax.swing.JPanel
 
 class SettingsUI : Configurable {
@@ -23,9 +25,14 @@ class SettingsUI : Configurable {
             component.themeIndex != ZeusThunderbolt.getCurrentThemeIndex() ||
             component.snowEnabled != ZeusThunderbolt.isSnowEnabled() ||
             component.regularParticlesEnabled != ZeusThunderbolt.isRegularParticlesEnabled() ||
+            component.regularParticlesIntensity != ZeusThunderbolt.getRegularParticlesIntensity() ||
             component.stardustParticlesEnabled != ZeusThunderbolt.isStardustParticlesEnabled() ||
+            component.stardustParticlesIntensity != ZeusThunderbolt.getStardustParticlesIntensity() ||
             component.reverseParticlesEnabled != ZeusThunderbolt.isReverseParticlesEnabled() ||
-            component.butterflyParticlesEnabled != ZeusThunderbolt.isButterfliesEnabled()
+            component.reverseParticlesIntensity != ZeusThunderbolt.getReverseParticlesIntensity() ||
+            component.butterflyParticlesEnabled != ZeusThunderbolt.isButterfliesEnabled() ||
+            component.butterflyParticlesIntensity != ZeusThunderbolt.getButterflyParticlesIntensity() ||
+            component.snowIntensity != ZeusThunderbolt.getSnowIntensity()
         } ?: false
 
     override fun apply() {
@@ -33,9 +40,14 @@ class SettingsUI : Configurable {
             ZeusThunderbolt.setTheme(component.themeIndex)
             ZeusThunderbolt.setSnowEnabled(component.snowEnabled)
             ZeusThunderbolt.setRegularParticlesEnabled(component.regularParticlesEnabled)
+            ZeusThunderbolt.setRegularParticlesIntensity(component.regularParticlesIntensity)
             ZeusThunderbolt.setStardustParticlesEnabled(component.stardustParticlesEnabled)
+            ZeusThunderbolt.setStardustParticlesIntensity(component.stardustParticlesIntensity)
             ZeusThunderbolt.setReverseParticlesEnabled(component.reverseParticlesEnabled)
+            ZeusThunderbolt.setReverseParticlesIntensity(component.reverseParticlesIntensity)
             ZeusThunderbolt.setButterfliesEnabled(component.butterflyParticlesEnabled)
+            ZeusThunderbolt.setButterflyParticlesIntensity(component.butterflyParticlesIntensity)
+            ZeusThunderbolt.setSnowIntensity(component.snowIntensity)
         }
     }
 
@@ -44,9 +56,14 @@ class SettingsUI : Configurable {
             component.themeIndex = ZeusThunderbolt.getCurrentThemeIndex()
             component.snowEnabled = ZeusThunderbolt.isSnowEnabled()
             component.regularParticlesEnabled = ZeusThunderbolt.isRegularParticlesEnabled()
+            component.regularParticlesIntensity = ZeusThunderbolt.getRegularParticlesIntensity()
             component.stardustParticlesEnabled = ZeusThunderbolt.isStardustParticlesEnabled()
+            component.stardustParticlesIntensity = ZeusThunderbolt.getStardustParticlesIntensity()
             component.reverseParticlesEnabled = ZeusThunderbolt.isReverseParticlesEnabled()
+            component.reverseParticlesIntensity = ZeusThunderbolt.getReverseParticlesIntensity()
             component.butterflyParticlesEnabled = ZeusThunderbolt.isButterfliesEnabled()
+            component.butterflyParticlesIntensity = ZeusThunderbolt.getButterflyParticlesIntensity()
+            component.snowIntensity = ZeusThunderbolt.getSnowIntensity()
         }
     }
 
@@ -59,22 +76,39 @@ class ThunderSettingsComponent {
     private val themeCombo = JComboBox(ZeusThunderbolt.getThemeNames().toTypedArray())
     private val snowCheckbox = JBCheckBox("Enable Snow Effect", ZeusThunderbolt.isSnowEnabled())
     private val regularParticlesCheckbox = JBCheckBox("Enable Regular Particles", ZeusThunderbolt.isRegularParticlesEnabled())
+    private val regularParticlesIntensitySlider = createIntensitySlider(ZeusThunderbolt.getRegularParticlesIntensity())
     private val stardustParticlesCheckbox = JBCheckBox("Enable Stardust Particles", ZeusThunderbolt.isStardustParticlesEnabled())
+    private val stardustParticlesIntensitySlider = createIntensitySlider(ZeusThunderbolt.getStardustParticlesIntensity())
     private val reverseParticlesCheckbox = JBCheckBox("Enable Reverse Particles", ZeusThunderbolt.isReverseParticlesEnabled())
+    private val reverseParticlesIntensitySlider = createIntensitySlider(ZeusThunderbolt.getReverseParticlesIntensity())
     private val butterflyParticlesCheckbox = JBCheckBox("Enable Butterfly Particles", ZeusThunderbolt.isButterfliesEnabled())
+    private val butterflyParticlesIntensitySlider = createIntensitySlider(ZeusThunderbolt.getButterflyParticlesIntensity())
+    private val snowIntensitySlider = createIntensitySlider(ZeusThunderbolt.getSnowIntensity())
     val panel: JPanel
 
     init {
         themeCombo.selectedIndex = ZeusThunderbolt.getCurrentThemeIndex()
         panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("Effect Theme:"), themeCombo)
-            .addComponent(regularParticlesCheckbox)
-            .addComponent(stardustParticlesCheckbox)
-            .addComponent(snowCheckbox)
-            .addComponent(reverseParticlesCheckbox)
-            .addComponent(butterflyParticlesCheckbox)
+            .addComponent(createEffectRow(regularParticlesCheckbox, regularParticlesIntensitySlider))
+            .addComponent(createEffectRow(stardustParticlesCheckbox, stardustParticlesIntensitySlider))
+            .addComponent(createEffectRow(snowCheckbox, snowIntensitySlider))
+            .addComponent(createEffectRow(reverseParticlesCheckbox, reverseParticlesIntensitySlider))
+            .addComponent(createEffectRow(butterflyParticlesCheckbox, butterflyParticlesIntensitySlider))
             .addComponentFillVertically(JPanel(), 0)
             .panel
+    }
+
+    private fun createIntensitySlider(currentValue: Int) = JSlider(0, 100, currentValue).apply {
+        majorTickSpacing = 25
+        minorTickSpacing = 5
+        paintTicks = true
+        toolTipText = "Effect intensity"
+    }
+
+    private fun createEffectRow(checkBox: JBCheckBox, slider: JSlider) = JPanel(BorderLayout(12, 0)).apply {
+        add(checkBox, BorderLayout.WEST)
+        add(slider, BorderLayout.CENTER)
     }
 
     var themeIndex: Int
@@ -95,10 +129,22 @@ class ThunderSettingsComponent {
             regularParticlesCheckbox.isSelected = value
         }
 
+    var regularParticlesIntensity: Int
+        get() = regularParticlesIntensitySlider.value
+        set(value) {
+            regularParticlesIntensitySlider.value = value
+        }
+
     var stardustParticlesEnabled: Boolean
         get() = stardustParticlesCheckbox.isSelected
         set(value) {
             stardustParticlesCheckbox.isSelected = value
+        }
+
+    var stardustParticlesIntensity: Int
+        get() = stardustParticlesIntensitySlider.value
+        set(value) {
+            stardustParticlesIntensitySlider.value = value
         }
 
     var reverseParticlesEnabled: Boolean
@@ -107,9 +153,27 @@ class ThunderSettingsComponent {
             reverseParticlesCheckbox.isSelected = value
         }
 
+    var reverseParticlesIntensity: Int
+        get() = reverseParticlesIntensitySlider.value
+        set(value) {
+            reverseParticlesIntensitySlider.value = value
+        }
+
     var butterflyParticlesEnabled: Boolean
         get() = butterflyParticlesCheckbox.isSelected
         set(value) {
             butterflyParticlesCheckbox.isSelected = value
+        }
+
+    var butterflyParticlesIntensity: Int
+        get() = butterflyParticlesIntensitySlider.value
+        set(value) {
+            butterflyParticlesIntensitySlider.value = value
+        }
+
+    var snowIntensity: Int
+        get() = snowIntensitySlider.value
+        set(value) {
+            snowIntensitySlider.value = value
         }
 }

--- a/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
+++ b/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
@@ -83,41 +83,74 @@ object ZeusThunderbolt : ApplicationActivationListener {
     private var snowEnabled = DEFAULT_SNOW_ENABLED
 
     const val DEFAULT_REGULAR_PARTICLES_ENABLED = true
+    const val DEFAULT_REGULAR_PARTICLES_INTENSITY = 100
 
     private var regularParticlesEnabled = DEFAULT_REGULAR_PARTICLES_ENABLED
+    private var regularParticlesIntensity = DEFAULT_REGULAR_PARTICLES_INTENSITY
 
     fun isRegularParticlesEnabled() = regularParticlesEnabled
     fun setRegularParticlesEnabled(enabled: Boolean) {
         regularParticlesEnabled = enabled
         settings.regularParticlesEnabled = enabled
     }
+    fun getRegularParticlesIntensity() = regularParticlesIntensity
+    fun setRegularParticlesIntensity(intensity: Int) {
+        regularParticlesIntensity = intensity.coerceIn(0, 100)
+        settings.regularParticlesIntensity = regularParticlesIntensity
+    }
 
     const val DEFAULT_STARDUST_PARTICLES_ENABLED = false
+    const val DEFAULT_STARDUST_PARTICLES_INTENSITY = 100
 
     private var stardustParticlesEnabled = DEFAULT_STARDUST_PARTICLES_ENABLED
+    private var stardustParticlesIntensity = DEFAULT_STARDUST_PARTICLES_INTENSITY
 
     fun isStardustParticlesEnabled() = stardustParticlesEnabled
     fun setStardustParticlesEnabled(enabled: Boolean) {
         stardustParticlesEnabled = enabled
         settings.stardustParticlesEnabled = enabled
     }
+    fun getStardustParticlesIntensity() = stardustParticlesIntensity
+    fun setStardustParticlesIntensity(intensity: Int) {
+        stardustParticlesIntensity = intensity.coerceIn(0, 100)
+        settings.stardustParticlesIntensity = stardustParticlesIntensity
+    }
 
     const val DEFAULT_REVERSE_PARTICLES_ENABLED = false
+    const val DEFAULT_REVERSE_PARTICLES_INTENSITY = 100
     private var reverseParticlesEnabled = DEFAULT_REVERSE_PARTICLES_ENABLED
+    private var reverseParticlesIntensity = DEFAULT_REVERSE_PARTICLES_INTENSITY
 
     fun isReverseParticlesEnabled() = reverseParticlesEnabled
     fun setReverseParticlesEnabled(enabled: Boolean) {
         reverseParticlesEnabled = enabled
         settings.reverseParticlesEnabled = enabled
     }
+    fun getReverseParticlesIntensity() = reverseParticlesIntensity
+    fun setReverseParticlesIntensity(intensity: Int) {
+        reverseParticlesIntensity = intensity.coerceIn(0, 100)
+        settings.reverseParticlesIntensity = reverseParticlesIntensity
+    }
 
     const val DEFAULT_BUTTERFLY_PARTICLES_ENABLED = false
+    const val DEFAULT_BUTTERFLY_PARTICLES_INTENSITY = 100
     private var butterflyParticlesEnabled = DEFAULT_BUTTERFLY_PARTICLES_ENABLED
+    private var butterflyParticlesIntensity = DEFAULT_BUTTERFLY_PARTICLES_INTENSITY
 
     fun isButterfliesEnabled() = butterflyParticlesEnabled
     fun setButterfliesEnabled(enabled: Boolean) {
         butterflyParticlesEnabled = enabled
         settings.butterflyParticlesEnabled = enabled
+    }
+    fun getButterflyParticlesIntensity() = butterflyParticlesIntensity
+    fun setButterflyParticlesIntensity(intensity: Int) {
+        butterflyParticlesIntensity = intensity.coerceIn(0, 100)
+        settings.butterflyParticlesIntensity = butterflyParticlesIntensity
+    }
+    fun getSnowIntensity() = snowIntensity
+    fun setSnowIntensity(intensity: Int) {
+        snowIntensity = intensity.coerceIn(0, 100)
+        settings.snowIntensity = snowIntensity
     }
 
     private inline fun <T> withElements(block: MutableList<PhysicsElement>.() -> T): T =
@@ -207,14 +240,20 @@ object ZeusThunderbolt : ApplicationActivationListener {
         snowEnabled = enabled
         settings.snowEnabled = enabled
     }
+    private var snowIntensity = 100
 
     private fun initPlugin() {
         setTheme(settings.themeIndex)
         setRegularParticlesEnabled(settings.regularParticlesEnabled)
+        setRegularParticlesIntensity(settings.regularParticlesIntensity)
         setStardustParticlesEnabled(settings.stardustParticlesEnabled)
+        setStardustParticlesIntensity(settings.stardustParticlesIntensity)
         setReverseParticlesEnabled(settings.reverseParticlesEnabled)
+        setReverseParticlesIntensity(settings.reverseParticlesIntensity)
         setSnowEnabled(settings.snowEnabled)
+        setSnowIntensity(settings.snowIntensity)
         setButterfliesEnabled(settings.butterflyParticlesEnabled)
+        setButterflyParticlesIntensity(settings.butterflyParticlesIntensity)
         val editorFactory = EditorFactory.getInstance()
         val editors = mutableListOf<Editor>()
         val lastPositions = mutableMapOf<Caret, Point>()
@@ -238,12 +277,13 @@ object ZeusThunderbolt : ApplicationActivationListener {
                     val loadFactor =
                         (activeReverseParticles.toFloat() / MAX_ACTIVE_REVERSE_PARTICLES).coerceIn(0f, 1f)
                     // Create reverse particles at deletion point
+                    val reverseIntensityFactor = reverseParticlesIntensity.toFloat() / 100f
                     addElement(
                         generateReverseParticle(
                             x0 = scrollOffsetX,
                             y0 = scrollOffsetY,
                             point = point,
-                            particleCount = (10 - (6 * loadFactor)).toInt().coerceAtLeast(3),
+                            particleCount = ((10 - (6 * loadFactor)) * reverseIntensityFactor).toInt().coerceAtLeast(1),
                             lifetimeFrames = (90 - (40 * loadFactor)).toInt().coerceAtLeast(30)
                         )
                     )
@@ -256,7 +296,8 @@ object ZeusThunderbolt : ApplicationActivationListener {
             currEditorObj.set(System.identityHashCode(editor))
             val caret = event.caret ?: return@lambda
             val caretCount = editor.caretModel.caretCount.coerceAtLeast(1)
-            val particlesPerCaret = (10f / sqrt(caretCount.toFloat())).toInt().coerceAtLeast(1)
+            val regularIntensityFactor = regularParticlesIntensity.toFloat() / 100f
+            val particlesPerCaret = ((10f / sqrt(caretCount.toFloat())) * regularIntensityFactor).toInt().coerceAtLeast(1)
             val scrollOffsetX = editor.scrollingModel.horizontalScrollOffset.toFloat()
             val scrollOffsetY = editor.scrollingModel.verticalScrollOffset.toFloat()
             val newPos = caret.getPoint()
@@ -491,12 +532,14 @@ object ZeusThunderbolt : ApplicationActivationListener {
             while (snowSpawnAccumulator >= SNOW_SPAWN_RATE) {
                 snowSpawnAccumulator -= SNOW_SPAWN_RATE
 
-                if (activeSnowflakes < MAX_ACTIVE_SNOWFLAKES) {
+                val maxActiveSnowflakes = (MAX_ACTIVE_SNOWFLAKES * (snowIntensity / 100f)).toInt().coerceAtLeast(1)
+                if (activeSnowflakes < maxActiveSnowflakes) {
                     // Spawn amount based on typing intensity
                     val spawnCount = (MIN_SNOW_SPAWN +
                             (MAX_SNOW_SPAWN - MIN_SNOW_SPAWN) * typingSpeed).toInt()
+                        .coerceAtLeast(1) * (snowIntensity / 100f).coerceAtLeast(0.1f)
 
-                    val snowflakes = List(spawnCount) {
+                    val snowflakes = List(spawnCount.toInt().coerceAtLeast(1)) {
                         val randomX = (-100..1100).random().toFloat()
                         val layer = (0 until SNOW_LAYERS).random()
                         generateSnowflake(0f, 0f, Point(randomX.toInt(), 0), layer)
@@ -555,16 +598,25 @@ object ZeusThunderbolt : ApplicationActivationListener {
         }
     }
 
-    private fun generateParticles(x0: Float, y0: Float, point: Point, count: Int = 10): List<PhysicsElement> =
-        (1..count).mapNotNull {
-            when {
-                snowEnabled && random.nextFloat() in 0.7f..0.9f -> generateSnowflake(x0, y0, point)
-                stardustParticlesEnabled && random.nextFloat() > 0.8f -> generateStardustParticle(x0, y0, point)
-                butterflyParticlesEnabled && random.nextFloat() > 0.95f -> generateButterfly(x0, y0, point)
-                regularParticlesEnabled -> generateRegularParticle(x0, y0, point)
-                else -> null
+    private fun generateParticles(x0: Float, y0: Float, point: Point, count: Int = 10): List<PhysicsElement> {
+        val effects = mutableListOf<Pair<Int, () -> PhysicsElement>>()
+        if (snowEnabled) effects += snowIntensity.coerceAtLeast(1) to { generateSnowflake(x0, y0, point) }
+        if (stardustParticlesEnabled) effects += stardustParticlesIntensity.coerceAtLeast(1) to { generateStardustParticle(x0, y0, point) }
+        if (butterflyParticlesEnabled) effects += butterflyParticlesIntensity.coerceAtLeast(1) to { generateButterfly(x0, y0, point) }
+        if (regularParticlesEnabled) effects += regularParticlesIntensity.coerceAtLeast(1) to { generateRegularParticle(x0, y0, point) }
+        if (effects.isEmpty()) return emptyList()
+
+        val totalWeight = effects.sumOf { it.first }
+        return (1..count).map {
+            val randomWeight = random.nextInt(totalWeight)
+            var cumulative = 0
+            val selected = effects.first { (weight, _) ->
+                cumulative += weight
+                randomWeight < cumulative
             }
+            selected.second.invoke()
         }
+    }
 
     private fun generateRegularParticle(x0: Float, y0: Float, point: Point) =
         particlePool.poll()?.apply {
@@ -1692,10 +1744,15 @@ private fun ClosedFloatingPointRange<Float>.random(): Float =
 class ThunderSettings : PersistentStateComponent<ThunderSettings> {
     var themeIndex: Int = -1 // Default to "None" theme
     var regularParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_REGULAR_PARTICLES_ENABLED
+    var regularParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_REGULAR_PARTICLES_INTENSITY
     var stardustParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_STARDUST_PARTICLES_ENABLED
+    var stardustParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_STARDUST_PARTICLES_INTENSITY
     var snowEnabled: Boolean = ZeusThunderbolt.DEFAULT_SNOW_ENABLED
+    var snowIntensity: Int = 100
     var reverseParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_REVERSE_PARTICLES_ENABLED
+    var reverseParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_REVERSE_PARTICLES_INTENSITY
     var butterflyParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_BUTTERFLY_PARTICLES_ENABLED
+    var butterflyParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_BUTTERFLY_PARTICLES_INTENSITY
 
     override fun getState(): ThunderSettings = this
 

--- a/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
+++ b/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
@@ -63,6 +63,16 @@ object ZeusThunderbolt : ApplicationActivationListener {
     private val random = Random()
     private val themes = Theme.entries.toTypedArray()
     private var currentTheme = Theme.None
+    private data class TypingEffectWeights(
+        val snow: Int = 0,
+        val stardust: Int = 0,
+        val butterfly: Int = 0,
+        val regular: Int = 0,
+    ) {
+        val total: Int = snow + stardust + butterfly + regular
+    }
+    @Volatile
+    private var typingEffectWeights = TypingEffectWeights()
 
     private const val SNOW_FADE_OUT_TIME = 5f  // Time in seconds after typing stops
     private const val SNOW_SPAWN_RATE = 0.1f   // Time between snowflake spawns
@@ -80,7 +90,9 @@ object ZeusThunderbolt : ApplicationActivationListener {
     private var typeCount = 0                 // Count of recent keystrokes
 
     const val DEFAULT_SNOW_ENABLED = false
+    const val DEFAULT_SNOW_INTENSITY = 100
     private var snowEnabled = DEFAULT_SNOW_ENABLED
+    private var snowIntensity = DEFAULT_SNOW_INTENSITY
 
     const val DEFAULT_REGULAR_PARTICLES_ENABLED = true
     const val DEFAULT_REGULAR_PARTICLES_INTENSITY = 100
@@ -92,11 +104,13 @@ object ZeusThunderbolt : ApplicationActivationListener {
     fun setRegularParticlesEnabled(enabled: Boolean) {
         regularParticlesEnabled = enabled
         settings.regularParticlesEnabled = enabled
+        refreshTypingEffectWeights()
     }
     fun getRegularParticlesIntensity() = regularParticlesIntensity
     fun setRegularParticlesIntensity(intensity: Int) {
         regularParticlesIntensity = intensity.coerceIn(0, 100)
         settings.regularParticlesIntensity = regularParticlesIntensity
+        refreshTypingEffectWeights()
     }
 
     const val DEFAULT_STARDUST_PARTICLES_ENABLED = false
@@ -109,11 +123,13 @@ object ZeusThunderbolt : ApplicationActivationListener {
     fun setStardustParticlesEnabled(enabled: Boolean) {
         stardustParticlesEnabled = enabled
         settings.stardustParticlesEnabled = enabled
+        refreshTypingEffectWeights()
     }
     fun getStardustParticlesIntensity() = stardustParticlesIntensity
     fun setStardustParticlesIntensity(intensity: Int) {
         stardustParticlesIntensity = intensity.coerceIn(0, 100)
         settings.stardustParticlesIntensity = stardustParticlesIntensity
+        refreshTypingEffectWeights()
     }
 
     const val DEFAULT_REVERSE_PARTICLES_ENABLED = false
@@ -141,16 +157,28 @@ object ZeusThunderbolt : ApplicationActivationListener {
     fun setButterfliesEnabled(enabled: Boolean) {
         butterflyParticlesEnabled = enabled
         settings.butterflyParticlesEnabled = enabled
+        refreshTypingEffectWeights()
     }
     fun getButterflyParticlesIntensity() = butterflyParticlesIntensity
     fun setButterflyParticlesIntensity(intensity: Int) {
         butterflyParticlesIntensity = intensity.coerceIn(0, 100)
         settings.butterflyParticlesIntensity = butterflyParticlesIntensity
+        refreshTypingEffectWeights()
     }
     fun getSnowIntensity() = snowIntensity
     fun setSnowIntensity(intensity: Int) {
         snowIntensity = intensity.coerceIn(0, 100)
         settings.snowIntensity = snowIntensity
+        refreshTypingEffectWeights()
+    }
+
+    private fun refreshTypingEffectWeights() {
+        typingEffectWeights = TypingEffectWeights(
+            snow = if (snowEnabled) snowIntensity else 0,
+            stardust = if (stardustParticlesEnabled) stardustParticlesIntensity else 0,
+            butterfly = if (butterflyParticlesEnabled) butterflyParticlesIntensity else 0,
+            regular = if (regularParticlesEnabled) regularParticlesIntensity else 0
+        )
     }
 
     private inline fun <T> withElements(block: MutableList<PhysicsElement>.() -> T): T =
@@ -239,8 +267,8 @@ object ZeusThunderbolt : ApplicationActivationListener {
     fun setSnowEnabled(enabled: Boolean) {
         snowEnabled = enabled
         settings.snowEnabled = enabled
+        refreshTypingEffectWeights()
     }
-    private var snowIntensity = 100
 
     private fun initPlugin() {
         setTheme(settings.themeIndex)
@@ -278,12 +306,16 @@ object ZeusThunderbolt : ApplicationActivationListener {
                         (activeReverseParticles.toFloat() / MAX_ACTIVE_REVERSE_PARTICLES).coerceIn(0f, 1f)
                     // Create reverse particles at deletion point
                     val reverseIntensityFactor = reverseParticlesIntensity.toFloat() / 100f
+                    if (reverseIntensityFactor <= 0f) return
+                    val reverseParticleCount =
+                        ((10 - (6 * loadFactor)) * reverseIntensityFactor).toInt().coerceAtLeast(0)
+                    if (reverseParticleCount <= 0) return
                     addElement(
                         generateReverseParticle(
                             x0 = scrollOffsetX,
                             y0 = scrollOffsetY,
                             point = point,
-                            particleCount = ((10 - (6 * loadFactor)) * reverseIntensityFactor).toInt().coerceAtLeast(1),
+                            particleCount = reverseParticleCount,
                             lifetimeFrames = (90 - (40 * loadFactor)).toInt().coerceAtLeast(30)
                         )
                     )
@@ -296,8 +328,13 @@ object ZeusThunderbolt : ApplicationActivationListener {
             currEditorObj.set(System.identityHashCode(editor))
             val caret = event.caret ?: return@lambda
             val caretCount = editor.caretModel.caretCount.coerceAtLeast(1)
-            val regularIntensityFactor = regularParticlesIntensity.toFloat() / 100f
-            val particlesPerCaret = ((10f / sqrt(caretCount.toFloat())) * regularIntensityFactor).toInt().coerceAtLeast(1)
+            val weights = typingEffectWeights
+            if (weights.total <= 0) return@lambda
+            val enabledEffects = listOf(weights.snow, weights.stardust, weights.butterfly, weights.regular)
+                .count { it > 0 }
+                .coerceAtLeast(1)
+            val aggregateTypingIntensity = (weights.total.toFloat() / enabledEffects) / 100f
+            val particlesPerCaret = ((10f / sqrt(caretCount.toFloat())) * aggregateTypingIntensity).toInt().coerceAtLeast(1)
             val scrollOffsetX = editor.scrollingModel.horizontalScrollOffset.toFloat()
             val scrollOffsetY = editor.scrollingModel.verticalScrollOffset.toFloat()
             val newPos = caret.getPoint()
@@ -532,14 +569,15 @@ object ZeusThunderbolt : ApplicationActivationListener {
             while (snowSpawnAccumulator >= SNOW_SPAWN_RATE) {
                 snowSpawnAccumulator -= SNOW_SPAWN_RATE
 
-                val maxActiveSnowflakes = (MAX_ACTIVE_SNOWFLAKES * (snowIntensity / 100f)).toInt().coerceAtLeast(1)
+                val snowIntensityFactor = snowIntensity / 100f
+                val maxActiveSnowflakes = (MAX_ACTIVE_SNOWFLAKES * snowIntensityFactor).toInt().coerceAtLeast(0)
                 if (activeSnowflakes < maxActiveSnowflakes) {
                     // Spawn amount based on typing intensity
                     val spawnCount = (MIN_SNOW_SPAWN +
                             (MAX_SNOW_SPAWN - MIN_SNOW_SPAWN) * typingSpeed).toInt()
-                        .coerceAtLeast(1) * (snowIntensity / 100f).coerceAtLeast(0.1f)
+                        .coerceAtLeast(1) * snowIntensityFactor
 
-                    val snowflakes = List(spawnCount.toInt().coerceAtLeast(1)) {
+                    val snowflakes = List(spawnCount.toInt().coerceAtLeast(0)) {
                         val randomX = (-100..1100).random().toFloat()
                         val layer = (0 until SNOW_LAYERS).random()
                         generateSnowflake(0f, 0f, Point(randomX.toInt(), 0), layer)
@@ -599,22 +637,18 @@ object ZeusThunderbolt : ApplicationActivationListener {
     }
 
     private fun generateParticles(x0: Float, y0: Float, point: Point, count: Int = 10): List<PhysicsElement> {
-        val effects = mutableListOf<Pair<Int, () -> PhysicsElement>>()
-        if (snowEnabled) effects += snowIntensity.coerceAtLeast(1) to { generateSnowflake(x0, y0, point) }
-        if (stardustParticlesEnabled) effects += stardustParticlesIntensity.coerceAtLeast(1) to { generateStardustParticle(x0, y0, point) }
-        if (butterflyParticlesEnabled) effects += butterflyParticlesIntensity.coerceAtLeast(1) to { generateButterfly(x0, y0, point) }
-        if (regularParticlesEnabled) effects += regularParticlesIntensity.coerceAtLeast(1) to { generateRegularParticle(x0, y0, point) }
-        if (effects.isEmpty()) return emptyList()
+        val weights = typingEffectWeights
+        val totalWeight = weights.total
+        if (totalWeight <= 0 || count <= 0) return emptyList()
 
-        val totalWeight = effects.sumOf { it.first }
         return (1..count).map {
             val randomWeight = random.nextInt(totalWeight)
-            var cumulative = 0
-            val selected = effects.first { (weight, _) ->
-                cumulative += weight
-                randomWeight < cumulative
+            when {
+                randomWeight < weights.snow -> generateSnowflake(x0, y0, point)
+                randomWeight < weights.snow + weights.stardust -> generateStardustParticle(x0, y0, point)
+                randomWeight < weights.snow + weights.stardust + weights.butterfly -> generateButterfly(x0, y0, point)
+                else -> generateRegularParticle(x0, y0, point)
             }
-            selected.second.invoke()
         }
     }
 
@@ -1748,7 +1782,7 @@ class ThunderSettings : PersistentStateComponent<ThunderSettings> {
     var stardustParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_STARDUST_PARTICLES_ENABLED
     var stardustParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_STARDUST_PARTICLES_INTENSITY
     var snowEnabled: Boolean = ZeusThunderbolt.DEFAULT_SNOW_ENABLED
-    var snowIntensity: Int = 100
+    var snowIntensity: Int = ZeusThunderbolt.DEFAULT_SNOW_INTENSITY
     var reverseParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_REVERSE_PARTICLES_ENABLED
     var reverseParticlesIntensity: Int = ZeusThunderbolt.DEFAULT_REVERSE_PARTICLES_INTENSITY
     var butterflyParticlesEnabled: Boolean = ZeusThunderbolt.DEFAULT_BUTTERFLY_PARTICLES_ENABLED


### PR DESCRIPTION
### Motivation
- Provide per-effect intensity controls so users can tune how strong each visual effect (regular, stardust, snow, reverse, butterfly) appears. 
- Persist intensity settings across IDE restarts and expose them in the existing Settings UI.

### Description
- Added intensity constants/fields/getters/setters and persistence for each effect in `ZeusThunderbolt` and `ThunderSettings` (`DEFAULT_*_INTENSITY`, `*_Intensity` fields, `get*/set*` methods). 
- Extended runtime behavior to respect intensities: caret particle count scaling for regular particles, reverse deletion particle counts, snow spawn cap and spawn counts, and weighted selection between enabled effects in `generateParticles`. 
- Updated the settings UI (`SettingsUI.kt`) to add a `JSlider` (0–100) for each effect and combined checkbox+slider rows via `createEffectRow`, and wired slider values into `isModified`, `apply`, and `reset`. 
- Files modified: `src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt` and `src/main/kotlin/com/zeus/thunderbolt/SettingsUI.kt`.

### Testing
- Ran `./gradlew test` which completed successfully (build successful); the project compiled and the test task reported `NO-SOURCE` (no unit tests present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c154b74c8328984ffdc85c43d6c0)