### PR TITLE
Add Qodana artifact upload and resolve inspection-style warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,9 +167,10 @@ jobs:
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2024.2
+        uses: JetBrains/qodana-action@v2024.2.5
         with:
           cache-default-branch-only: true
+          upload-result: true
 
   # Run plugin structure verification along with IntelliJ Plugin Verifier
   verify:

--- a/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
+++ b/src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt
@@ -22,7 +22,6 @@ import java.awt.geom.Point2D
 import java.awt.geom.CubicCurve2D
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
-import javax.swing.JComponent
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
@@ -30,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import kotlinx.coroutines.*
 import java.awt.geom.Ellipse2D
 import java.awt.geom.Path2D
+import javax.swing.JComponent
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -766,11 +766,11 @@ class ZeusThunderbolt : ApplicationActivationListener {
                 val maxActiveSnowflakes = (MAX_ACTIVE_SNOWFLAKES * snowIntensityFactor).toInt().coerceAtLeast(0)
                 if (activeSnowflakes < maxActiveSnowflakes) {
                     // Spawn amount based on typing intensity
-                    val spawnCount = (MIN_SNOW_SPAWN +
+                    val spawnCount = ((MIN_SNOW_SPAWN +
                             (MAX_SNOW_SPAWN - MIN_SNOW_SPAWN) * typingSpeed).toInt()
-                        .coerceAtLeast(1) * snowIntensityFactor
+                        .coerceAtLeast(1) * snowIntensityFactor).toInt().coerceAtLeast(0)
 
-                    val snowflakes = List(spawnCount.toInt().coerceAtLeast(0)) {
+                    val snowflakes = List(spawnCount) {
                         val randomX = (-100..1100).random().toFloat()
                         val layer = (0 until SNOW_LAYERS).random()
                         generateSnowflake(0f, 0f, Point(randomX.toInt(), 0), layer)
@@ -1905,7 +1905,7 @@ class ZeusThunderbolt : ApplicationActivationListener {
             val leftWing = Path2D.Float()
             g2d.transform = originalTransform
             g2d.translate(x.toDouble(), y.toDouble())
-            g2d.rotate(leftWingAngle*1.0)
+            g2d.rotate(leftWingAngle.toDouble())
             createWingPath(leftWing, -1)
             g2d.paint = createWingGradient(alpha)
             g2d.fill(leftWing)
@@ -1915,7 +1915,7 @@ class ZeusThunderbolt : ApplicationActivationListener {
             val rightWing = Path2D.Float()
             g2d.transform = originalTransform
             g2d.translate(x.toDouble(), y.toDouble())
-            g2d.rotate(rightWingAngle*1.0)
+            g2d.rotate(rightWingAngle.toDouble())
             createWingPath(rightWing, 1)
             g2d.paint = createWingGradient(alpha)
             g2d.fill(rightWing)


### PR DESCRIPTION
### Motivation
- Integrate Qodana inspections into CI with accessible artifacts for easier debugging of reported issues.
- Silence small inspection-style warnings in rendering and spawn-count code to satisfy Qodana/JVM community checks and avoid redundant conversions.

### Description
- Update the Qodana GitHub Action to `JetBrains/qodana-action@v2024.2.5` and enable `upload-result: true` so inspection artifacts are uploaded from CI (`.github/workflows/build.yml`).
- Simplify snow spawn-count computation to produce an `Int` directly and use it to allocate the spawn `List`, removing redundant `toInt()` calls (`ZeusThunderbolt.updateSnow`).
- Replace implicit numeric multiplication hacks (`* 1.0`) with explicit `toDouble()` calls when calling `Graphics2D.rotate` for clarity and to satisfy inspections (`ZeusThunderbolt.render` butterfly wing rotation).
- Add the missing `javax.swing.JComponent` import to fix a compile-time unresolved reference introduced during cleanup (`src/main/kotlin/com/zeus/thunderbolt/ZeusThunderbolt.kt`).

### Testing
- Ran `./gradlew compileKotlin` which completed successfully after the fixes.
- Ran `./gradlew check` twice: the first run failed due to a missing `JComponent` import, the import was added, and the subsequent `./gradlew check` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e880f6502483288d8217e9d16c46f9)