### PR TITLE
Fix Marketplace archive extraction failure (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-12
+
+### Fixed
+
+- Build the plugin distribution with a space-free archive name (`Zeus-Thunderbolt`) so the JetBrains
+  Marketplace no longer fails compatibility verification with "The plugin archive file cannot be
+  extracted". The visible plugin name remains "Zeus Thunderbolt".
+
 ## [1.1.9] - 2026-04-22
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
 // Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
 intellijPlatform {
     pluginConfiguration {
+        // rootProject.name is space-free ("Zeus-Thunderbolt") to keep the archive/jar entry paths
+        // clean; set the visible marketplace display name explicitly so it stays "Zeus Thunderbolt".
+        name = "Zeus Thunderbolt"
         version = providers.gradleProperty("pluginVersion")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.dmitrysamoylenko.zeusthunderbolt
 pluginName = Zeus Thunderbolt Idea
 pluginRepositoryUrl = https://github.com/samoylenkodmitry/Zeus-Thunderbolt-Idea-Plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.9
+pluginVersion = 1.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 252

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,9 @@
-rootProject.name = "Zeus Thunderbolt"
+// Space-free project name so the produced distribution folder AND the bundled jars
+// (archivesName defaults to rootProject.name) have no spaces in their ZIP entry paths.
+// Spaces there trigger the JetBrains Marketplace "The plugin archive file cannot be
+// extracted" verification failure (MP-7472). The visible plugin name is set separately
+// via intellijPlatform.pluginConfiguration.name in build.gradle.kts.
+rootProject.name = "Zeus-Thunderbolt"
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"


### PR DESCRIPTION
## Problem

JetBrains Marketplace compatibility verification reports for **1.1.9**:

> Zeus Thunderbolt 1.1.9 configuration is invalid. — The plugin archive file cannot be extracted

## Root cause

The distribution packed everything under a folder and jars whose names contain a **space**:

```
Zeus Thunderbolt/
Zeus Thunderbolt/lib/Zeus Thunderbolt-1.1.9.jar
Zeus Thunderbolt/lib/Zeus Thunderbolt-1.1.9-searchableOptions.jar
```

That space comes from `rootProject.name = "Zeus Thunderbolt"` in `settings.gradle.kts`. Special characters (including spaces) in ZIP entry paths are the documented trigger for this Marketplace failure (JetBrains ticket MP-7472). The uploaded zips are otherwise valid (`unzip -t` passes) — the verifier chokes on the entry names.

## Fix

- `settings.gradle.kts`: `rootProject.name` → `"Zeus-Thunderbolt"` (space-free) so both the distribution folder **and** the bundled jars (jar `archivesName` defaults to `rootProject.name`) have clean entry paths.
- `build.gradle.kts`: set `intellijPlatform.pluginConfiguration.name = "Zeus Thunderbolt"` so the visible Marketplace display name is unchanged.
- Bump `pluginVersion` to `1.2.0` + CHANGELOG entry.

Plugin `<id>` (`com.dmitrysamoylenko.zeusthunderbolt`) is unchanged, so this publishes as an **update** to the existing listing.

## Verification

Built locally with `./gradlew buildPlugin`. Resulting archive entries:

```
Zeus-Thunderbolt/
Zeus-Thunderbolt/lib/Zeus-Thunderbolt-1.2.0.jar
Zeus-Thunderbolt/lib/Zeus-Thunderbolt-1.2.0-searchableOptions.jar
```

No spaces anywhere; `plugin.xml` still has `<name>Zeus Thunderbolt</name>` and the original `<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)