### PR TITLE
Disable CI execution for fork pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
 
   # Prepare environment and build the plugin
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Build
     runs-on: ubuntu-latest
     outputs:
@@ -95,6 +96,7 @@ jobs:
 
   # Run tests and upload a code coverage report
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Test
     needs: [ build ]
     runs-on: ubuntu-latest
@@ -135,6 +137,7 @@ jobs:
 
   # Run Qodana inspections and provide report
   inspectCode:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Inspect code
     needs: [ build ]
     runs-on: ubuntu-latest
@@ -174,6 +177,7 @@ jobs:
 
   # Run plugin structure verification along with IntelliJ Plugin Verifier
   verify:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Verify plugin
     needs: [ build ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- prevent fork-originated pull requests from executing CI jobs
- preserve normal checks for same-repository pull requests and trusted push/tag/manual events
- pair workflow guards with the repository policy requiring approval for all external contributors

## Validation

- all workflow YAML files parsed successfully
- git diff --check passed